### PR TITLE
Fix `plugin_data` field assignment.

### DIFF
--- a/greeter_plugin/greeter_summary.py
+++ b/greeter_plugin/greeter_summary.py
@@ -51,20 +51,22 @@ def op(name,
   if display_name is None:
     display_name = name
 
-
-  summary_metadata = tf.SummaryMetadata()
   # We could put additional metadata other than the PLUGIN_NAME,
   # but we don't need any metadata for this simple example.
-  summary_metadata.plugin_data.plugin_name = PLUGIN_NAME
-  summary_metadata.plugin_data.content = ""
+  summary_metadata = tf.SummaryMetadata(
+      display_name=display_name,
+      summary_description=description,
+      plugin_data=tf.SummaryMetadata.PluginData(
+          plugin_name=PLUGIN_NAME,
+          content=''))
+       
   message = tf.string_join(['Hello, ', guest, '!'])
+
   # Return a summary op that is properly configured.
   return tf.summary.tensor_summary(
       name,
       message,
-      display_name=display_name,
       summary_metadata=summary_metadata,
-      summary_description=description,
       collections=collections)
 
 
@@ -82,12 +84,15 @@ def pb(tag, guest, display_name=None, description=None):
   message = 'Hello, %s!' % guest
   tensor = tf.make_tensor_proto(message, dtype=tf.string)
 
-  summary_metadata = tf.SummaryMetadata(display_name=display_name,
-                                        summary_description=description)
   # We have no metadata to store, but we do need to add a plugin_data entry
   # so that we know this summary is associated with the greeter plugin.
-  summary_metadata.plugin_data.plugin_name = PLUGIN_NAME
-  summary_metadata.plugin_data.content = '{}'
+  metadata_content = '{}'
+  summary_metadata = tf.SummaryMetadata(
+      display_name=display_name,
+      summary_description=description,
+      plugin_data=tf.SummaryMetadata.PluginData(
+          plugin_name=PLUGIN_NAME,
+          content=metadata_content))
 
   summary = tf.Summary()
   summary.value.add(tag=tag,

--- a/greeter_plugin/greeter_summary.py
+++ b/greeter_plugin/greeter_summary.py
@@ -55,7 +55,8 @@ def op(name,
   summary_metadata = tf.SummaryMetadata()
   # We could put additional metadata other than the PLUGIN_NAME,
   # but we don't need any metadata for this simple example.
-  summary_metadata.plugin_data.add(plugin_name=PLUGIN_NAME, content="")
+  summary_metadata.plugin_data.plugin_name = PLUGIN_NAME
+  summary_metadata.plugin_data.content = ""
   message = tf.string_join(['Hello, ', guest, '!'])
   # Return a summary op that is properly configured.
   return tf.summary.tensor_summary(
@@ -85,9 +86,8 @@ def pb(tag, guest, display_name=None, description=None):
                                         summary_description=description)
   # We have no metadata to store, but we do need to add a plugin_data entry
   # so that we know this summary is associated with the greeter plugin.
-  metadata_content = '{}'
-  summary_metadata.plugin_data.add(plugin_name=PLUGIN_NAME,
-                                   content=metadata_content)
+  summary_metadata.plugin_data.plugin_name = PLUGIN_NAME
+  summary_metadata.plugin_data.content = '{}'
 
   summary = tf.Summary()
   summary.value.add(tag=tag,


### PR DESCRIPTION
Set the fields of `plugin_data` with direct assignment instead through a call to add().

Calling the add() method raises an error because `plugin_data` is no longer a repeated field, as seen in the changes of this commit: https://github.com/tensorflow/tensorflow/commit/4c60c96257bfd54a036d15af979e90fc0b4e400d. Setting `plugin_data`'s field values with direct assignment fixes the issue.