### PR TITLE
Make reload accept run and tag parameters.

### DIFF
--- a/greeter_plugin/greeter-card.html
+++ b/greeter_plugin/greeter-card.html
@@ -89,16 +89,16 @@ limitations under the License.
         // the requestManager has been set from above. (Polymer is tricky
         // sometimes)
         this._attached = true;
-        this.reload();
+        this.reload(this.run, this.tag);
       },
-      reload() {
+      reload(run, tag) {
         if (!this._attached) {
           return;
         }
         this._canceller.cancelAll();
         const router = getRouter();
         const url = router.pluginRunTagRoute("greeter", "/greetings")(
-          this.tag, this.run);
+          tag, run);
         const updateData = this._canceller.cancellable(result => {
           if (result.cancelled) {
             return;


### PR DESCRIPTION
It is a good practice for observer callbacks to use their accepted arguments instead of properties on the module object. See docs for Polymer: https://www.polymer-project.org/1.0/docs/devguide/observers#dependencies

This closes #5.