### PR TITLE
Make reload for greeter-card take no arguments

### DIFF
--- a/greeter_plugin/greeter-card.html
+++ b/greeter_plugin/greeter-card.html
@@ -78,20 +78,22 @@ limitations under the License.
         },
       },
 
-      observers: ["reload(run, tag)"],
+      observers: ["_fetchNewData(run, tag)"],
 
       _computeRunColor(run) {
         return this._colorScaleFunction(run);
       },
-
       attached() {
         // Defer reloading until after we're attached, because that ensures that
         // the requestManager has been set from above. (Polymer is tricky
         // sometimes)
         this._attached = true;
-        this.reload(this.run, this.tag);
+        this.reload();
       },
-      reload(run, tag) {
+      reload() {
+        this._fetchNewData(this.run, this.tag);
+      },
+      _fetchNewData(run, tag) {
         if (!this._attached) {
           return;
         }


### PR DESCRIPTION
The greeter card's reload method used to take run and tag arguments, which caused a bug (#11) because the greeter dashboard would call the card's reload method with no arguments.

We now introduce a new _fetchNewData(run, tag) method to the greeter-card component which is used as an observer and used indirectly by the card's reload method.

Fixes #11.