### PR TITLE
Pass summary metadata content as bytes instead of strings

### DIFF
--- a/greeter_plugin/greeter_summary.py
+++ b/greeter_plugin/greeter_summary.py
@@ -52,14 +52,14 @@ def op(name,
   if display_name is None:
     display_name = name
 
-  # We could put additional metadata other than the PLUGIN_NAME,
-  # but we don't need any metadata for this simple example.
+  # We could pass additional metadata other than the PLUGIN_NAME within the
+  # plugin data by using the content parameter, but we don't need any metadata
+  # for this simple example.
   summary_metadata = tf.SummaryMetadata(
       display_name=display_name,
       summary_description=description,
       plugin_data=tf.SummaryMetadata.PluginData(
-          plugin_name=PLUGIN_NAME,
-          content=b''))
+          plugin_name=PLUGIN_NAME))
 
   message = tf.string_join(['Hello, ', guest, '!'])
 
@@ -87,13 +87,13 @@ def pb(tag, guest, display_name=None, description=None):
 
   # We have no metadata to store, but we do need to add a plugin_data entry
   # so that we know this summary is associated with the greeter plugin.
-  metadata_content = '{}'
+  # We could use this entry to pass additional metadata other than the
+  # PLUGIN_NAME by using the content parameter.
   summary_metadata = tf.SummaryMetadata(
       display_name=display_name,
       summary_description=description,
       plugin_data=tf.SummaryMetadata.PluginData(
-          plugin_name=PLUGIN_NAME,
-          content=metadata_content.encode('utf-8')))
+          plugin_name=PLUGIN_NAME))
 
   summary = tf.Summary()
   summary.value.add(tag=tag,

--- a/greeter_plugin/greeter_summary.py
+++ b/greeter_plugin/greeter_summary.py
@@ -59,7 +59,7 @@ def op(name,
       summary_description=description,
       plugin_data=tf.SummaryMetadata.PluginData(
           plugin_name=PLUGIN_NAME,
-          content=''))
+          content=b''))
 
   message = tf.string_join(['Hello, ', guest, '!'])
 
@@ -93,7 +93,7 @@ def pb(tag, guest, display_name=None, description=None):
       summary_description=description,
       plugin_data=tf.SummaryMetadata.PluginData(
           plugin_name=PLUGIN_NAME,
-          content=metadata_content))
+          content=metadata_content.encode('utf-8')))
 
   summary = tf.Summary()
   summary.value.add(tag=tag,


### PR DESCRIPTION
Fixes #14: When using Tensorflow 1.4.0 or later, `SummaryMetadata` accepts bytes instead of a string as its content which caused the build to fail. This change was made in tensorflow/tensorflow@4d24e67.

Passing encoded strings instead resolves this issue, making it possible to build the plugin example using the latest Tensorflow version.