### PR TITLE
Fix the intructions to work inside of a Docker container

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,8 @@ To test out the custom “greeter TensorBoard” with the Greeter Plugin, first 
 Then, clone and `cd` into this repository, and run the following commands:
 
 ```sh
-bazel run //greeter_plugin:greeter_demo
-bazel run //greeter_tensorboard -- --logdir=/tmp/greeter_demo
+bazel run //greeter_plugin:greeter_demo --incompatible_remove_native_http_archive=false
+bazel run //greeter_tensorboard --incompatible_remove_native_http_archive=false -- --logdir=/tmp/greeter_demo
 ```
 
 [install Bazel]: https://bazel.build/versions/master/docs/install.html


### PR DESCRIPTION
This PR allows to get the demo working in a Docker container. The following dump should justify the fixes suggested:

```bash
~/tensorboard-plugin-example# TensorBoard 1.12.0 at http://913f3daf7877:6006 (Press CTRL+C to quit)
bazel run //greeter_plugin:greeter_demo
Starting local Bazel server and connecting to it...
INFO: Invocation ID: 6804814a-633f-4ffc-8b7f-eea8f2657543
ERROR: error loading package '': Encountered error while reading extension file 'closure/defs.bzl': no such package '@io_bazel_rules_closure//closure': The native http_archive rule is deprecated. load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive") for a drop-in replacement.
Use --incompatible_remove_native_http_archive=false to temporarily continue using the native rule.
ERROR: error loading package '': Encountered error while reading extension file 'closure/defs.bzl': no such package '@io_bazel_rules_closure//closure': The native http_archive rule is deprecated. load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive") for a drop-in replacement.
Use --incompatible_remove_native_http_archive=false to temporarily continue using the native rule.
INFO: Elapsed time: 3.417s
INFO: 0 processes.
FAILED: Build did NOT complete successfully (0 packages loaded)
FAILED: Build did NOT complete successfully (0 packages loaded)
    Fetching @io_bazel_rules_closure; fetching


root@913f3daf7877:~/tensorboard-plugin-example# bazel run //greeter_plugin:greeter_demo --incompatible_remove_native_http_archive=false
INFO: Invocation ID: 4b45fd68-7f3f-45ac-a7bb-b9da4e286ca1
INFO: Analysed target //greeter_plugin:greeter_demo (13 packages loaded, 105 targets configured).
INFO: Found 1 target...
Target //greeter_plugin:greeter_demo up-to-date:
  bazel-bin/greeter_plugin/greeter_demo
INFO: Elapsed time: 51.475s, Critical Path: 0.05s
INFO: 0 processes.
INFO: Build completed successfully, 4 total actions
INFO: Build completed successfully, 4 total actions
Saving output to /tmp/greeter_demo.
2018-12-15 15:12:58.823760: I tensorflow/core/platform/cpu_feature_guard.cc:141] Your CPU supports instructions that this TensorFlow binary was not compiled to use: AVX2 FMA
Done. Output saved to /tmp/greeter_demo.

bazel run //greeter_tensorboard -- --logdir=/tmp/greeter_demo
INFO: Invocation ID: 3902dad5-5d62-490f-ba04-4cf1c5320e16
INFO: Build options have changed, discarding analysis cache.
ERROR: /root/tensorboard-plugin-example/greeter_tensorboard/BUILD:7:1: no such package '@org_pocoo_werkzeug//': The native new_http_archive rule is deprecated. load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive") for a drop-in replacement.
Use --incompatible_remove_native_http_archive=false to temporarily continue using the native rule. and referenced by '//greeter_tensorboard:greeter_tensorboard'
ERROR: Analysis of target '//greeter_tensorboard:greeter_tensorboard' failed; build aborted: no such package '@org_pocoo_werkzeug//': The native new_http_archive rule is deprecated. load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive") for a drop-in replacement.
Use --incompatible_remove_native_http_archive=false to temporarily continue using the native rule.
INFO: Elapsed time: 0.829s
INFO: 0 processes.
FAILED: Build did NOT complete successfully (7 packages loaded, 22 targets configured)
FAILED: Build did NOT complete successfully (7 packages loaded, 22 targets configured)
    currently loading: @bazel_tools//tools/zip
    Fetching @org_pocoo_werkzeug; fetching


~/tensorboard-plugin-example# bazel run //greeter_tensorboard --incompatible_remove_native_http_archive=false -- --logdir=/tmp/greeter_demo
INFO: Invocation ID: 2b5e52d3-a81c-438f-ac58-6acdad9733af
INFO: Build options have changed, discarding analysis cache.
INFO: Analysed target //greeter_tensorboard:greeter_tensorboard (280 packages loaded, 5141 targets configured).
INFO: Found 1 target...
INFO: From ProtoCompile external/org_tensorflow_tensorboard/tensorboard/plugins/profile/trace_events_pb2.py:
external/com_google_protobuf/python: warning: directory does not exist.
...
```